### PR TITLE
Add whitelist support and tests (Addresses #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ __pycache__/
 /dist/
 /.eggs/
 
+# virtual environments
+/.venv/
+/venv/
+
 # Sphinx documentation
 /docs/_build/
 

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ refresh_all_requirements:
 
 requirements.txt requirements-dev.txt : %.txt : %.txt.in
 	[ ! -e .requirements-env ] || exit 1
-	virtualenv .requirements-env
+	virtualenv .requirements-env -p "$(which python)"
 	.requirements-env/bin/pip install -r $@
 	.requirements-env/bin/pip install -r $<
 	echo "# You should not edit this file directly.  Instead, you should edit $<." >| $@

--- a/README.md
+++ b/README.md
@@ -153,6 +153,22 @@ given buckets** before populating them with test fixture data, please ensure the
 
     tests/fixtures/populate.py --s3-bucket $DSS_S3_BUCKET_TEST_FIXTURES --gs-bucket $DSS_GS_BUCKET_TEST_FIXTURES
 
+#### Set up the whitelist
+
+Follow [instructions here](https://github.com/ucsc-cgp/bouncer#setting-up-the-whitelist) to set up the whitelist.
+The convention for naming the whitelist is `commons/DSS_DEPLOYMENT_STAGE/whitelist`, substituting `DSS_DEPLOYMENT_STAGE`
+for its value.
+
+Then you will need to add the environment variable `EMAIL_WHITELIST_NAME` to your `environment.local` with the value as
+the name from the previous step. Then run
+```
+source environment
+```
+
+Since you are using service account credentials for you local deployment you will need to use the email listed in your
+`gcp-credentials.json` which is long and contains your GCP project ID among other details. This email is also viewable in
+the GCP console under the IAM section. It is the `member` field for the key you downloaded. Put this email address in the
+whitelist you created.
 
 #### Running tests
 

--- a/README.md
+++ b/README.md
@@ -155,20 +155,34 @@ given buckets** before populating them with test fixture data, please ensure the
 
 #### Set up the whitelist
 
-Follow [instructions here](https://github.com/ucsc-cgp/bouncer#setting-up-the-whitelist) to set up the whitelist.
-The convention for naming the whitelist is `commons/DSS_DEPLOYMENT_STAGE/whitelist`, substituting `DSS_DEPLOYMENT_STAGE`
-for its value.
+1. Follow [instructions here](https://github.com/ucsc-cgp/bouncer#setting-up-the-whitelist) to set up the whitelist.
+   The convention for naming the whitelist is `commons/DSS_DEPLOYMENT_STAGE/whitelist`, substituting `DSS_DEPLOYMENT_STAGE`
+   for its value.
 
-Then you will need to add the environment variable `EMAIL_WHITELIST_NAME` to your `environment.local` with the value as
-the name from the previous step. Then run
-```
-source environment
-```
+2. Then you will need to adjust your environment. Copy this snippet and add it to your `environment.local`
 
-Since you are using service account credentials for you local deployment you will need to use the email listed in your
-`gcp-credentials.json` which is long and contains your GCP project ID among other details. This email is also viewable in
-the GCP console under the IAM section. It is the `member` field for the key you downloaded. Put this email address in the
-whitelist you created.
+   ```
+   EXPORT_ENV_VARS_TO_LAMBDA_ARRAY+=(
+       EMAIL_WHITELIST_NAME
+       )
+   ```
+
+   Also add the variable `EMAIL_WHITELIST_NAME` to your `environment.local` with the value as
+   the name from the previous step. For example one might add
+
+   ```
+   EMAIL_WHITELIST_NAME=commons/DSS_DEPLOYMENT_STAGE/whitelist
+   ```
+
+   Then run
+   ```
+   source environment
+   ```
+
+3. Since you are using service account credentials for you local deployment you will need to use the email listed in your
+   `gcp-credentials.json` which is long and contains your GCP project ID among other details. This email is also viewable in
+   the GCP console under the IAM section. It is the `member` field for the key you downloaded. Put this email address in the
+   whitelist you created.
 
 #### Running tests
 

--- a/README.md
+++ b/README.md
@@ -159,19 +159,20 @@ given buckets** before populating them with test fixture data, please ensure the
    The convention for naming the whitelist is `commons/DSS_DEPLOYMENT_STAGE/whitelist`, substituting `DSS_DEPLOYMENT_STAGE`
    for its value.
 
-2. Then you will need to adjust your environment. Copy this snippet and add it to your `environment.local`
+2. Next you will need to adjust your environment. Copy this snippet and add it to your `environment.local`
 
    ```
-   EXPORT_ENV_VARS_TO_LAMBDA_ARRAY+=(
-       EMAIL_WHITELIST_NAME
-       )
+   # only add if it's not already in the list of vars
+   if [[ $EXPORT_ENV_VARS_TO_LAMBDA != *"EMAIL_WHITELIST_NAME"* ]]; then
+     EXPORT_ENV_VARS_TO_LAMBDA+=" EMAIL_WHITELIST_NAME"
+   fi
    ```
 
    Also add the variable `EMAIL_WHITELIST_NAME` to your `environment.local` with the value as
    the name from the previous step. For example one might add
 
    ```
-   EMAIL_WHITELIST_NAME=commons/DSS_DEPLOYMENT_STAGE/whitelist
+   EMAIL_WHITELIST_NAME=commons/${DSS_DEPLOYMENT_STAGE}/whitelist
    ```
 
    Then run
@@ -182,7 +183,7 @@ given buckets** before populating them with test fixture data, please ensure the
 3. Since you are using service account credentials for you local deployment you will need to use the email listed in your
    `gcp-credentials.json` which is long and contains your GCP project ID among other details. This email is also viewable in
    the GCP console under the IAM section. It is the `member` field for the key you downloaded. Put this email address in the
-   whitelist you created.
+   whitelist you created by following [these instructions](https://github.com/ucsc-cgp/bouncer#adding-someone-to-the-whitelist).
 
 #### Running tests
 

--- a/dss/config.py
+++ b/dss/config.py
@@ -102,6 +102,7 @@ class Config:
     BLOBSTORE_RETRIES: int = None
 
     _ALLOWED_EMAILS: typing.Optional[str] = None
+    _EMAIL_WHITELIST: typing.Optional[str] = None
     _CURRENT_CONFIG: BucketConfig = BucketConfig.ILLEGAL
     _NOTIFICATION_SENDER_EMAIL: typing.Optional[str] = None
 
@@ -277,6 +278,25 @@ class Config:
             Config._ALLOWED_EMAILS = os.environ[envvar]
 
         return Config._ALLOWED_EMAILS
+
+    @staticmethod
+    def get_email_whitelist_name() -> str:
+        if Config._EMAIL_WHITELIST is None:
+            if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
+                envvar = "EMAIL_WHITELIST_NAME"
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST:
+                envvar = "EMAIL_WHITELIST_NAME"
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST_FIXTURE:
+                envvar = "EMAIL_WHITELIST_NAME"
+            elif Config._CURRENT_CONFIG == BucketConfig.ILLEGAL:
+                raise Exception("email whitelist is not set")
+
+            if envvar not in os.environ:
+                raise Exception(
+                    f"Please set the {envvar} environment variable")
+            Config._EMAIL_WHITELIST = os.environ[envvar]
+
+        return Config._EMAIL_WHITELIST
 
     @staticmethod
     def get_es_index_name(index_type: ESIndexType,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ botocore==1.10.16
 cachetools==2.0.1
 certifi==2018.1.18
 cffi==1.11.2
+cgp-bouncer==0.1.0
 chalice==1.1.0
 chardet==3.0.4
 click==6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ botocore==1.10.16
 cachetools==2.0.1
 certifi==2018.1.18
 cffi==1.11.2
+cgp-bouncer==0.1.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -2,6 +2,7 @@
 azure-storage >= 0.36.0
 boto3 >= 1.6.0
 botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
+cgp-bouncer >= 0.1.0
 cloud-blobstore >= 2.1.4
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
 elasticsearch >= 5.4.0, < 6.0.0


### PR DESCRIPTION
This adds whitelist support for the data store.

What's new:
- instructions are added for setting up the whitelist and other environment variables necessary
- the whitelist checking mechanism is added and working
- tests ensure that the whitelist works once configured properly